### PR TITLE
Subscribes to custom tick event instead

### DIFF
--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from "react";
 import "./Timer.css";
 
 const Timer = () => {
-  const workoutCount = 5;
-  const [appState, setAppState] = useState({ count: 8, state: "stopped" });
+  const workoutCount = 5.0;
+  const [appState, setAppState] = useState({ count: workoutCount, state: "stopped" });
+  const [timer, setTimer] = useState(null)
   const cooldownCount = 3;
 
   //Pure Function
@@ -13,7 +14,7 @@ const Timer = () => {
     }
 
     if (state.count > 0) {
-      return { count: state.count - 1, state: state.state };
+      return { count: Math.max(state.count - 0.05, 0), state: state.state };
     } else {
       // get below 0
       if (state.state == "workout")
@@ -25,10 +26,16 @@ const Timer = () => {
   };
 
   const startTimer = () => {
+    let interval = setInterval(() => {
+      const event = new CustomEvent("tick");
+      document.dispatchEvent(event)
+    }, 50)
+    setTimer(interval);
     setAppState({ count: workoutCount, state: "workout" });
   };
 
   const stopTimer = () => {
+    clearInterval(timer);
     setAppState({ count: workoutCount, state: "stopped" });
   };
 
@@ -41,19 +48,19 @@ const Timer = () => {
   };
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    let listener = document.addEventListener("tick", () => {
       setAppState((prevState) => {
-        console.log(prevState);
-        return newTick(prevState, cooldownCount, workoutCount);
+        return newTick(prevState, cooldownCount, workoutCount)
       });
-    }, 1000);
-    return () => clearInterval(interval);
+    });
+   
+    return document.removeEventListener("tick", listener)
   }, []);
 
   return (
     <div>
       <button className="timerBtn" onClick={toggleTimer}>
-        {appState.count}
+        {appState.count.toLocaleString(undefined, {maximumFractionDigits:2, minimumFractionDigits: 2}) }
       </button>
     </div>
   );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,5 @@ import App from './App.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
     <App />
-  </React.StrictMode>,
 )


### PR DESCRIPTION
I wasn't entirely satisfied with how we did it. I feel like there was a better way without having an interval constantly run in the background.

How other tutorials seem to have done it, is they continually create and destroy new intervals (at least maybe that's how I understood it), which I was also not a fan of as well.

So, I thought about it for a bit, I felt like subscribing to an external event in `useEffect` made a lot of sense. Since use effect imo shouldn't worry about how an interval is created, it should only worry about external "side-effects".

This allows the toggle button to correctly create and destroy intervals (since it makes sense that the button should trigger that), but the useEffect can properly subscribe to any "tick" events.

I also changed the tick interval from every 1000ms to every 50ms.  Just for fun.